### PR TITLE
fix url generation in xml files

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,4 @@
-baseURL: "https://madewhere.co/"
+baseURL: "https://madewhere.co"
 title: "madewhere"
 copyright: madewhere Contributors
 


### PR DESCRIPTION
xml files had extra slashes in them, seemingly because of this trailing slash